### PR TITLE
Add initial test and building of wasm structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+osi.wasm: data/licenses/osi.rego | build_dir
+	opa build -t wasm -e licenses/is_osi $<
+	@tar -xf bundle.tar.gz /policy.wasm >/dev/null 2>&1
+	@mv policy.wasm build/$@
+	@${RM} bundle.tar.gz
+
+test-osi: data/licenses/osi.rego
+	opa test $< tests/ -r test_osi* -v
+
+.PHONY: build_dir
+build_dir:
+	@mkdir -p build
+
+.PHONY: clean
+clean:
+	@${RM} -rf build

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,35 @@
+# Open Policy Agent policy rules
+
+This repository contains OPA policy rules.
+
+## Installing OPA
+
+link:https://www.openpolicyagent.org/docs/latest/#running-opa[running-opa]
+
+The following version was used during development:
+----
+$ opa version
+Version: 0.45.0
+Build Commit: 523c285bcc417b2ec8a26b0a248407b1e840d488
+Build Timestamp: 2022-10-07T18:38:08Z
+Build Hostname: 3710e50c71de
+Go Version: go1.19.2
+Platform: linux/amd64
+WebAssembly: available
+----
+
+## Testing
+----
+$ make test-osi
+opa test data/licenses/osi.rego tests/ -r test_osi* -v
+tests/test-osi.rego:
+data.test_osi.test_is_osi: PASS (432.94µs)
+--------------------------------------------------------------------------------
+PASS: 1/1
+----
+
+## Building wasm policy modules
+----
+$ make osi.wasm
+----
+The wasm module will be available in the `build` directory.

--- a/tests/test-osi.rego
+++ b/tests/test-osi.rego
@@ -1,0 +1,25 @@
+package test_osi
+
+import future.keywords
+import data.licenses.is_osi
+
+list := [{
+  "reference": "https://spdx.org/licenses/Apache-2.0.html",
+  "isDeprecatedLicenseId": false,
+  "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+  "referenceNumber": 119,
+  "name": "Apache License 2.0",
+  "licenseId": "Apache-2.0",
+  "seeAlso": [
+    "https://www.apache.org/licenses/LICENSE-2.0",
+    "https://opensource.org/licenses/Apache-2.0"
+  ],
+  "isOsiApproved": true,
+  "isFsfLibre": true
+}]
+
+test_is_osi if {
+  r := is_osi with input.licenseId as "Apache-2.0"
+              with data.licenses.licenses as list
+  r == true
+}


### PR DESCRIPTION
This commit adds a single test for the osi policy rules as a suggestion for how test could be added to this project. There is also a make target that builds a OPA policy wasm bundle.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>