### PR TITLE
Update package name for osi policy rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ osi.wasm: data/licenses/osi.rego | build_dir
 	@mv policy.wasm build/$@
 	@${RM} bundle.tar.gz
 
+define opa_test
+	opa test $^ tests/ -r $1 -v
+endef
+
 test-osi: data/licenses/osi.rego data/licenses/not_osi.rego
-	opa test $^ tests/ -r test_*_osi* -v
+	@$(call opa_test,test_*_osi*)
+
+test-network: data/licenses/network_copyleft.rego
+	@$(call opa_test,test_*_network*)
+
+test: test-osi test-network
 
 .PHONY: build_dir
 build_dir:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 osi.wasm: data/licenses/osi.rego | build_dir
-	opa build -t wasm -e licenses/is_osi $<
+	opa build -t wasm -e osi_policy/is_osi $<
 	@tar -xf bundle.tar.gz /policy.wasm >/dev/null 2>&1
 	@mv policy.wasm build/$@
 	@${RM} bundle.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ test-network: data/licenses/network_copyleft.rego
 test-permissive: data/licenses/permissive.rego
 	@$(call opa_test,test_*_permissive*)
 
-test: test-osi test-network test-permissive
+test-public_domain: data/licenses/public_domain.rego
+	@$(call opa_test,test_*_public_domain*)
+
+test: test-osi test-network test-permissive test-public_domain
 
 .PHONY: build_dir
 build_dir:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ test-permissive: data/licenses/permissive.rego
 test-public_domain: data/licenses/public_domain.rego
 	@$(call opa_test,test_*_public_domain*)
 
-test: test-osi test-network test-permissive test-public_domain
+test-strong_copyleft: data/licenses/strong_copyleft.rego
+	@$(call opa_test,test_*_strong_copyleft*)
+
+test: test-osi test-network test-permissive test-public_domain \
+	test-strong_copyleft
 
 .PHONY: build_dir
 build_dir:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ osi.wasm: data/licenses/osi.rego | build_dir
 	@mv policy.wasm build/$@
 	@${RM} bundle.tar.gz
 
-test-osi: data/licenses/osi.rego
-	opa test $< tests/ -r test_osi* -v
+test-osi: data/licenses/osi.rego data/licenses/not_osi.rego
+	opa test $^ tests/ -r test_*_osi* -v
 
 .PHONY: build_dir
 build_dir:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ test-public_domain: data/licenses/public_domain.rego
 test-strong_copyleft: data/licenses/strong_copyleft.rego
 	@$(call opa_test,test_*_strong_copyleft*)
 
+test-weak_copyleft: data/licenses/weak_copyleft.rego
+	@$(call opa_test,test_*_weak_copyleft*)
+
 test: test-osi test-network test-permissive test-public_domain \
-	test-strong_copyleft
+	test-strong_copyleft test-weak_copyleft
 
 .PHONY: build_dir
 build_dir:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ test-osi: data/licenses/osi.rego data/licenses/not_osi.rego
 test-network: data/licenses/network_copyleft.rego
 	@$(call opa_test,test_*_network*)
 
-test: test-osi test-network
+test-permissive: data/licenses/permissive.rego
+	@$(call opa_test,test_*_permissive*)
+
+test: test-osi test-network test-permissive
 
 .PHONY: build_dir
 build_dir:

--- a/data/licenses/network_copyleft.rego
+++ b/data/licenses/network_copyleft.rego
@@ -1,4 +1,4 @@
-package licenses
+package network
 
 import data.licenses
 
@@ -19,7 +19,7 @@ network_copyleft_ids := [
 ]
 
 network_copyleft[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.licenseId == network_copyleft_ids[_]
 }
 

--- a/data/licenses/not_osi.rego
+++ b/data/licenses/not_osi.rego
@@ -1,9 +1,9 @@
-package licenses
+package osi_policy
 
 import data.licenses
 
 not_osi[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.isOsiApproved == false
 }
 

--- a/data/licenses/osi.rego
+++ b/data/licenses/osi.rego
@@ -1,9 +1,9 @@
-package licenses
+package osi_policy
 
 import data.licenses
 
 osi[license] {
-    license := licenses.licenses[_]
+    license := data.licenses[_]
     license.isOsiApproved == true
 }
 

--- a/data/licenses/permissive.rego
+++ b/data/licenses/permissive.rego
@@ -1,4 +1,4 @@
-package licenses
+package permissive
 
 import data.licenses
 
@@ -26,14 +26,14 @@ permissive_ids := [
 ]
 
 permissive[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.licenseId == permissive_ids[_]
 }
 
 default is_permissive := false
 
 is_permissive {
-  license := public_domain[_]
+  license := permissive[_]
   license.licenseId == input.licenseId
 }
 

--- a/data/licenses/public_domain.rego
+++ b/data/licenses/public_domain.rego
@@ -1,4 +1,4 @@
-package licenses
+package public_domain
 
 import data.licenses
 
@@ -10,7 +10,7 @@ public_domain_ids := [
 ]
 
 public_domain[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.licenseId == public_domain_ids[_]
 }
 

--- a/data/licenses/strong_copyleft.rego
+++ b/data/licenses/strong_copyleft.rego
@@ -1,4 +1,4 @@
-package licenses
+package strong_copyleft
 
 import data.licenses
 
@@ -16,7 +16,7 @@ strong_copyleft_ids := [
 ]
 
 strong_copyleft[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.licenseId == strong_copyleft_ids[_]
 }
 

--- a/data/licenses/weak_copyleft.rego
+++ b/data/licenses/weak_copyleft.rego
@@ -1,4 +1,4 @@
-package licenses
+package weak_copyleft
 
 import data.licenses
 
@@ -24,7 +24,7 @@ weak_copyleft_ids := [
 ]
 
 weak_copyleft[license] {
-    license := licenses.licenses[_]
+    license := licenses[_]
     license.licenseId == weak_copyleft_ids[_]
 }
 

--- a/tests/test-network_copyleft.rego
+++ b/tests/test-network_copyleft.rego
@@ -1,0 +1,28 @@
+package test_network_policy
+
+import future.keywords
+import data.network.is_network_copyleft 
+
+list := [
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
+      "referenceNumber": 110,
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+]
+
+test_is_network_copyleft if {
+  r := is_network_copyleft with input.licenseId as "AGPL-3.0-only"
+              with data.licenses as list
+  r == true
+}
+

--- a/tests/test-osi.rego
+++ b/tests/test-osi.rego
@@ -1,7 +1,7 @@
-package test_osi
+package test_osi_policy
 
 import future.keywords
-import data.licenses.is_osi
+import data.osi_policy.is_osi
 
 list := [{
   "reference": "https://spdx.org/licenses/Apache-2.0.html",
@@ -20,6 +20,6 @@ list := [{
 
 test_is_osi if {
   r := is_osi with input.licenseId as "Apache-2.0"
-              with data.licenses.licenses as list
+              with data.licenses as list
   r == true
 }

--- a/tests/test-osi.rego
+++ b/tests/test-osi.rego
@@ -2,24 +2,46 @@ package test_osi_policy
 
 import future.keywords
 import data.osi_policy.is_osi
+import data.osi_policy.not_osi
 
-list := [{
-  "reference": "https://spdx.org/licenses/Apache-2.0.html",
-  "isDeprecatedLicenseId": false,
-  "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-  "referenceNumber": 119,
-  "name": "Apache License 2.0",
-  "licenseId": "Apache-2.0",
-  "seeAlso": [
-    "https://www.apache.org/licenses/LICENSE-2.0",
-    "https://opensource.org/licenses/Apache-2.0"
-  ],
-  "isOsiApproved": true,
-  "isFsfLibre": true
-}]
+list := [
+  {
+    "reference": "https://spdx.org/licenses/Apache-2.0.html",
+    "isDeprecatedLicenseId": false,
+    "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+    "referenceNumber": 119,
+    "name": "Apache License 2.0",
+    "licenseId": "Apache-2.0",
+    "seeAlso": [
+      "https://www.apache.org/licenses/LICENSE-2.0",
+      "https://opensource.org/licenses/Apache-2.0"
+    ],
+    "isOsiApproved": true,
+    "isFsfLibre": true
+  },
+  {
+    "reference": "https://spdx.org/licenses/CDDL-1.1.html",
+    "isDeprecatedLicenseId": false,
+    "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
+    "referenceNumber": 489,
+    "name": "Common Development and Distribution License 1.1",
+    "licenseId": "CDDL-1.1",
+    "seeAlso": [
+      "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
+      "https://javaee.github.io/glassfish/LICENSE"
+    ],
+    "isOsiApproved": false
+  }
+]
 
 test_is_osi if {
   r := is_osi with input.licenseId as "Apache-2.0"
               with data.licenses as list
   r == true
+}
+
+test_not_osi if {
+  n := not_osi[_] with data.licenses as list
+  n.licenseId == "CDDL-1.1"
+
 }

--- a/tests/test-permissive.rego
+++ b/tests/test-permissive.rego
@@ -1,0 +1,28 @@
+package test_permissive_policy
+
+import future.keywords
+import data.permissive.is_permissive 
+
+list := [
+    {
+      "reference": "https://spdx.org/licenses/Apache-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": 119,
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+]
+
+test_is_permissive if {
+  r := is_permissive with input.licenseId as "Apache-2.0"
+              with data.licenses as list
+  r == true
+}
+

--- a/tests/test-public_domain.rego
+++ b/tests/test-public_domain.rego
@@ -1,0 +1,27 @@
+package test_public_domain_policy
+
+import future.keywords
+import data.public_domain.is_public_domain
+
+list := [
+    {
+      "reference": "https://spdx.org/licenses/Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": 405,
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "https://unlicense.org/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+]
+
+test_is_public_domain if {
+  r := is_public_domain with input.licenseId as "Unlicense"
+              with data.licenses as list
+  r == true
+}
+

--- a/tests/test-strong_copyleft.rego
+++ b/tests/test-strong_copyleft.rego
@@ -1,0 +1,28 @@
+package test_strong_copyleft_policy
+
+import future.keywords
+import data.strong_copyleft.is_strong_copyleft
+
+list := [
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": 332,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+]
+
+test_is_strong_copyleft if {
+  r := is_strong_copyleft with input.licenseId as "GPL-3.0-only"
+              with data.licenses as list
+  r == true
+}
+

--- a/tests/test-weak_copyleft.rego
+++ b/tests/test-weak_copyleft.rego
@@ -1,0 +1,26 @@
+package test_weak_copyleft_policy
+
+import future.keywords
+import data.weak_copyleft.is_weak_copyleft
+
+list := [
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": 449,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+]
+
+test_is_weak_copyleft if {
+  r := is_weak_copyleft with input.licenseId as "LGPL-2.0"
+              with data.licenses as list
+  r == true
+}
+


### PR DESCRIPTION
This commit updates the package name of this policy rule enable having contructs like licenses.licenses.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>